### PR TITLE
R4 upgrade

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,4 @@
+^renv$
+^renv\.lock$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -12,8 +12,9 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, r: "3.6.1"}
-          - {os: macOS-latest,   r: "3.6.1"}
+          - {os: windows-latest, r: "4.0.5"}
+          - {os: macOS-latest,   r: "4.0.5"}
+          - {os: ubuntu-20.04,   r: "4.0.5"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: vandenman/jasp-actions/setup-test-env@support_ubuntu2
 
       - name: Make sure igraph is installed from source
-        run: install.packages("igraph", type = "source")
+        run: install.packages("igraph", type = "source", repos = "https://cloud.r-project.org/")
         shell: Rscript {0}
 
       - name: Run unit tests

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: jasp-stats/jasp-actions/setup-test-env@master
 
       - name: Make sure igraph is installed from source
+        if: ${{ runner.os == 'Linux' }}
         run: install.packages("igraph", type = "source", repos = "https://cloud.r-project.org/")
         shell: Rscript {0}
 

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,7 +28,8 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: jasp-stats/jasp-actions/setup-test-env@master
+      #- uses: jasp-stats/jasp-actions/setup-test-env@master
+      - uses: vandenman/jasp-actions/setup-test-env@support_ubuntu2
 
       - name: Run unit tests
         run: source("tests/testthat.R")

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -30,6 +30,7 @@ jobs:
 
       - uses: jasp-stats/jasp-actions/setup-test-env@master
 
+      # so Rstudio's binary for igraph appears to be incompatible (i.e., crashes hard) with GitHub actions. Instead, we install igraph from source
       - name: Make sure igraph is installed from source
         if: ${{ runner.os == 'Linux' }}
         run: install.packages("igraph", type = "source", repos = "https://cloud.r-project.org/")

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -28,8 +28,7 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
 
-      #- uses: jasp-stats/jasp-actions/setup-test-env@master
-      - uses: vandenman/jasp-actions/setup-test-env@support_ubuntu2
+      - uses: jasp-stats/jasp-actions/setup-test-env@master
 
       - name: Make sure igraph is installed from source
         run: install.packages("igraph", type = "source", repos = "https://cloud.r-project.org/")

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,6 +31,10 @@ jobs:
       #- uses: jasp-stats/jasp-actions/setup-test-env@master
       - uses: vandenman/jasp-actions/setup-test-env@support_ubuntu2
 
+      - name: Make sure igraph is installed from source
+        run: install.packages("igraph", type = "source")
+        shell: Rscript {0}
+
       - name: Run unit tests
         run: source("tests/testthat.R")
         shell: Rscript {0}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ state
 .Rproj.user/*
 Rproj.user
 .Rproj.user
+/.Rprofile
+/renv.lock
+/renv

--- a/R/networkanalysis.R
+++ b/R/networkanalysis.R
@@ -778,7 +778,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   for (v in names(allNetworks))
     networkPlotContainer[[v]] <- createJaspPlot(title = v, width = width[v], height = height[v])
 
-  jaspBase:::.suppressGrDevice({
+  jaspBase::.suppressGrDevice({
 
     for (v in names(allNetworks)) {
 
@@ -834,13 +834,13 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   for (v in names(bootstrapResults)) {
 
     bt <- bootstrapResults[[v]]
-    p <- try(jaspBase:::.suppressGrDevice(plot(bt, statistic = statistic, order = "sample")))
+    p <- try(jaspBase::.suppressGrDevice(plot(bt, statistic = statistic, order = "sample")))
 
     # sometimes bootnet catches an error and returns a faulty ggplot object.
     # here we ensure that if there was any error, e contains that error.
     e <- p
     if (!isTryError(p))
-      e <- try(jaspBase:::.suppressGrDevice(print(p)))
+      e <- try(jaspBase::.suppressGrDevice(print(p)))
 
     if (isTryError(e)) {
       plotContainer[[v]]$setError(gettextf("bootnet crashed with the following error message:\n%s", .extractErrorMessage(e)))
@@ -1040,7 +1040,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   # for every dataset do the analysis
   for (nw in seq_along(dataset)) {
 
-    jaspBase:::.suppressGrDevice(
+    jaspBase::.suppressGrDevice(
       msg <- capture.output(
         network <- bootnet::estimateNetwork(
           data    = dataset[[nw]],
@@ -1207,7 +1207,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
     if (layout == "data")
       layout <- "circle"
 
-    jaspBase:::.suppressGrDevice(layout <- qgraph::averageLayout(networks, layout = layout, repulsion = options[["repulsion"]]))
+    jaspBase::.suppressGrDevice(layout <- qgraph::averageLayout(networks, layout = layout, repulsion = options[["repulsion"]]))
     rownames(layout) <- .unv(colnames(networks[[1L]]))
 
   } else {
@@ -1299,12 +1299,19 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   noTicks <- if (options[["BootstrapType"]] == "jacknife") network[["network"]][[1L]][["nPerson"]] * nGraphs else options[["numberOfBootstraps"]] * nGraphs
 
   startProgressbar(noTicks * 2L, "Bootstrapping network")
+
+  original <- utils::setTxtProgressBar
+  on.exit(jaspBase:::assignFunctionInPackage(original, "setTxtProgressBar", "utils"))
+  jaspBase::assignFunctionInPackage(function(...) {
+    progressbarTick()
+  }, "setTxtProgressBar", "utils")
   tryCatch({
-    jaspBase:::.suppressGrDevice({
+    jaspBase::.suppressGrDevice({
       for (nm in names(allNetworks)) {
 
         # .networkAnalysisBootnetBootnet replaces bootnet::bootnet so we can have a progress bar
-        bootstrapResult[[nm]] <- .networkAnalysisBootnetBootnet(
+
+        bootstrapResult[[nm]] <- bootnet::bootnet(
           data       = allNetworks[[nm]],
           nBoots     = options[["numberOfBootstraps"]],
           type       = options[["BootstrapType"]],
@@ -1565,417 +1572,6 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
 }
 
 # functions modified from bootnet ----
-# exact duplicate of bootnet::bootnet but with progressbar
-.networkAnalysisBootnetBootnet <- function(data, nBoots = 1000,
-                                           default = c("none", "EBICglasso", "pcor", "IsingFit", "IsingSampler", "huge", "adalasso", "mgm", "relimp", "cor"),
-                                           type = c("nonparametric", "parametric", "node", "person", "jackknife", "case"),
-                                           nCores = 1, statistics = c("edge", "strength", "closeness", "betweenness"), model = c("detect", "GGM", "Ising"),
-                                           fun, prepFun, prepArgs, estFun, estArgs, graphFun, graphArgs, intFun, intArgs, verbose = TRUE,
-                                           construct = c("default", "function", "arguments"), labels, alpha = 1, caseMin = 0.05,
-                                           caseMax = 0.75, caseN = 10, subNodes = 2:(ncol(data) - 1),
-                                           subCases = round((1 - seq(caseMin, caseMax, length = caseN)) *
-                                                              nrow(data)), computeCentrality = TRUE, propBoot = 1,
-                                           replacement = TRUE, graph, sampleSize, intercepts, weighted,
-                                           signed, directed, ...
-                                           #progressbar = NULL, resultsForProgressbar = NULL, callback = NULL
-
-) {
-  if (default[[1]] == "glasso")
-    default <- "EBICglasso"
-  default <- match.arg(default)
-  type <- match.arg(type)
-  if (type == "case")
-    type <- "person"
-  model <- match.arg(model)
-  if (missing(data)) {
-    if (type != "parametric") {
-      warning("'data' can only be missing if type = 'parametric'. Setting type = 'parametric' and performing parametric bootstrap instead.")
-      type <- "parametric"
-    }
-    if (missing(graph)) {
-      stop("'graph' may not be missing in parametric bootstrap when 'data' is missing.")
-    }
-    if (missing(sampleSize)) {
-      stop("'sampleSize' may not be missing in parametric bootstrap when 'data' is missing.")
-    }
-    N <- ncol(graph)
-    Np <- sampleSize
-    if (missing(intercepts)) {
-      intercepts <- rep(0, Np)
-    }
-    if (!missing(data)) {
-      warning("'data' is ignored when using manual parametric bootstrap.")
-      data <- NULL
-    }
-    manual <- TRUE
-    dots <- list(...)
-  }
-  else {
-    manual <- FALSE
-    if (is(data, "bootnetResult")) {
-      default <- data$default
-      inputCheck <- data$.input
-      fun <- data$estimator
-      dots <- data$arguments
-      if (missing(weighted)) {
-        weighted <- data$weighted
-      }
-      if (missing(signed)) {
-        signed <- data$signed
-      }
-      if (missing(directed)) {
-        directed <- data$directed
-      }
-      data <- data$data
-      N <- ncol(data)
-      Np <- nrow(data)
-    }
-    else {
-      dots <- list(...)
-      N <- ncol(data)
-      Np <- nrow(data)
-      fun <- NULL
-      if (!manual) {
-        goodColumns <- sapply(data, function(x) is.numeric(x) |
-                                is.ordered(x) | is.integer(x))
-        if (!all(goodColumns)) {
-          if (verbose) {
-            warning(paste0("Removing non-numeric columns: ",
-                           paste(which(!goodColumns), collapse = "; ")))
-          }
-          data <- data[, goodColumns, drop = FALSE]
-        }
-      }
-    }
-  }
-  inputCheck <- bootnet:::checkInput(default = default, fun = fun, prepFun = prepFun,
-                                     prepArgs = prepArgs, estFun = estFun, estArgs = estArgs,
-                                     graphFun = graphFun, graphArgs = graphArgs, intFun = intFun,
-                                     intArgs = intArgs, sampleSize = Np, construct = construct,
-                                     .dots = dots)
-  if (missing(weighted)) {
-    weighted <- TRUE
-  }
-  if (missing(signed)) {
-    signed <- TRUE
-  }
-  if (missing(directed)) {
-    if (!default %in% c("graphicalVAR", "relimp", "DAG"))
-      directed <- FALSE
-  }
-  if (type == "jackknife") {
-    message("Jacknife overwrites nBoot to sample size")
-    nBoots <- Np
-  }
-  if (type == "node" & N < 3) {
-    stop("Node-wise bootstrapping requires at least three nodes.")
-  }
-  if (!manual && !(is.data.frame(data) || is.matrix(data))) {
-    stop("'data' argument must be a data frame")
-  }
-  if (!manual && is.matrix(data)) {
-    data <- as.data.frame(data)
-  }
-  if (missing(labels)) {
-    if (manual) {
-      labels <- colnames(graph)
-      if (is.null(labels)) {
-        labels <- seq_len(ncol(graph))
-      }
-    }
-    else {
-      labels <- colnames(data)
-      if (is.null(labels)) {
-        labels <- seq_len(ncol(data))
-      }
-    }
-  }
-  if (type == "parametric" & model == "detect") {
-    if (manual) {
-      stop("'model' must be set in parametric bootstrap without 'data'.")
-    }
-    if (default != "none") {
-      model <- ifelse(grepl("ising", default, ignore.case = TRUE),
-                      "Ising", "GGM")
-    }
-    else {
-      model <- ifelse(any(grepl("ising", deparse(estFun),
-                                ignore.case = TRUE)), "Ising", "GGM")
-    }
-    message(paste0("model set to '", model, "'"))
-  }
-  if (!manual) {
-    if (verbose) {
-      message("Estimating sample network...")
-    }
-    sampleResult <- bootnet::estimateNetwork(data, default = default,
-                                             fun = inputCheck$estimator, .dots = inputCheck$arguments,
-                                             labels = labels, verbose = verbose, weighted = weighted,
-                                             signed = signed, .input = inputCheck)
-  }
-  else {
-    sampleResult <- list(graph = graph, intercepts = intercepts,
-                         labels = labels, nNodes = N, nPerson = Np, estimator = inputCheck$estimator,
-                         arguments = inputCheck$arguments, default = default,
-                         weighted = weighted, signed = signed)
-    class(sampleResult) <- c("bootnetResult", "list")
-  }
-  if (nCores == 1) {
-    bootResults <- vector("list", nBoots)
-    if (verbose) {
-      message("Bootstrapping...")
-      pb <- txtProgressBar(0, nBoots, style = 3)
-    }
-    for (b in seq_len(nBoots)) {
-      tryLimit <- 10
-      tryCount <- 0
-      repeat {
-        if (!type %in% c("node", "person")) {
-          nNode <- N
-          inSample <- seq_len(N)
-          if (type == "jackknife") {
-            bootData <- data[-b, , drop = FALSE]
-            nPerson <- Np - 1
-          }
-          else if (type == "parametric") {
-            nPerson <- Np
-            if (model == "Ising") {
-              bootData <- IsingSampler::IsingSampler(round(propBoot *
-                                                             Np), noDiag(sampleResult$graph), sampleResult$intercepts)
-            }
-            else if (model == "GGM") {
-              g <- -sampleResult$graph
-              diag(g) <- 1
-              bootData <- mvtnorm::rmvnorm(round(propBoot *
-                                                   Np), sigma = corpcor::pseudoinverse(g))
-            }
-            else stop(paste0("Model '", model, "' not supported."))
-          }
-          else {
-            nPerson <- Np
-            bootData <- data[sample(seq_len(Np), round(propBoot *
-                                                         Np), replace = replacement), ]
-          }
-        }
-        else if (type == "node") {
-          nPerson <- Np
-          nNode <- sample(subNodes, 1)
-          inSample <- sort(sample(seq_len(N), nNode))
-          bootData <- data[, inSample, drop = FALSE]
-        }
-        else {
-          nNode <- ncol(data)
-          nPerson <- sample(subCases, 1)
-          inSample <- 1:N
-          persSample <- sort(sample(seq_len(Np), nPerson))
-          bootData <- data[persSample, , drop = FALSE]
-        }
-        if (!missing(prepFun)) {
-          if (!missing(prepArgs) & is.list(prepArgs) &
-              identical(prepFun, qgraph::cor_auto)) {
-            prepArgs$verbose <- FALSE
-          }
-        }
-        res <- suppressWarnings(try({
-          bootnet::estimateNetwork(bootData, default = default,
-                                   fun = inputCheck$estimator, .dots = inputCheck$arguments,
-                                   labels = labels[inSample], verbose = FALSE,
-                                   weighted = weighted, signed = signed, .input = inputCheck,
-                                   memorysaver = TRUE)
-        }))
-        if (is(res, "try-error")) {
-          if (tryCount == tryLimit) {
-            stop("Maximum number of errors in bootstraps reached")
-          }
-          tryCount <- tryCount + 1
-        }
-        else {
-          break
-        }
-
-      }
-      bootResults[[b]] <- res
-
-      progressbarTick()
-
-      if (verbose) {
-        setTxtProgressBar(pb, b)
-      }
-    }
-    if (verbose) {
-      close(pb)
-    }
-  }
-  else {
-    if (verbose) {
-      message("Bootstrapping...")
-    }
-
-    if (missing(graph)) {
-      graph <- matrix(0, N, N)
-    }
-    if (missing(data)) {
-      data <- matrix(0, Np, N)
-    }
-    if (missing(intercepts)) {
-      intercepts <- rep(0, N)
-    }
-    if (missing(sampleSize)) {
-      sampleSize <- Np
-    }
-    # excl <- c("prepFun", "prepArgs", "estFun", "estArgs",
-    #           "graphFun", "graphArgs", "intFun", "intArgs", "fun")
-    # objects to export
-    # objToExport <- ls(all.names = TRUE)[!ls(all.names = TRUE) %in% c(excl, "cl", "...")]
-
-    # TODO: this won't work with jaspResults!
-    objToExport <- c("type", "data", "N", "Np", "model", "propBoot",
-                     "sampleResult", "replacement", "subNodes", "subCases",
-                     "default", "inputCheck", "labels", "weighted", "signed")
-
-    setup <- .makeParallelSetup(pb = progressbar, objs = objToExport, env = environment())
-    on.exit(eval(setup$stopCluster))
-    `%dopar%` <- setup$dopar
-    cl <- setup[["cl"]]
-
-    # snow::clusterExport(cl = cl, list = objToExport, envir = environment())
-
-    # bootResults <- parallel::parLapply(cl, seq_len(nBoots), function(b) {
-    bootResults <- tryCatch(foreach::foreach(
-      b = seq_len(nBoots),
-      .options.snow=setup$progress,
-      .inorder = FALSE,
-      # .export = objToExport,
-      .packages = c("bootnet", "mvtnorm", "corpcor"),
-      .verbose = TRUE
-    ) %dopar% {
-      tryLimit <- 10
-      tryCount <- 0
-      repeat {
-        if (!type %in% c("node", "person")) {
-          nNode <- ncol(data)
-          inSample <- seq_len(N)
-          if (type == "jackknife") {
-            bootData <- data[-b, , drop = FALSE]
-            nPerson <- Np - 1
-          }
-          else if (type == "parametric") {
-            nPerson <- Np
-            if (model == "Ising") {
-              bootData <- IsingSampler::IsingSampler(round(propBoot *
-                                                             Np), noDiag(sampleResult$graph), sampleResult$intercepts)
-            }
-            else if (model == "GGM") {
-              g <- -sampleResult$graph
-              diag(g) <- 1
-              bootData <- mvtnorm::rmvnorm(round(propBoot *
-                                                   Np), sigma = corpcor::pseudoinverse(g))
-            }
-            else stop(paste0("Model '", model, "' not supported."))
-          }
-          else {
-            nPerson <- Np
-            bootData <- data[sample(seq_len(Np), round(propBoot *
-                                                         Np), replace = replacement), ]
-          }
-        }
-        else if (type == "node") {
-          nPerson <- Np
-          nNode <- sample(subNodes, 1)
-          inSample <- sort(sample(seq_len(N), nNode))
-          bootData <- data[, inSample, drop = FALSE]
-        }
-        else {
-          nNode <- ncol(data)
-          nPerson <- sample(subCases, 1)
-          inSample <- 1:N
-          persSample <- sort(sample(seq_len(Np), nPerson))
-          bootData <- data[persSample, , drop = FALSE]
-        }
-        res <- suppressWarnings(try({
-          bootnet::estimateNetwork(bootData, default = default,
-                                   fun = inputCheck$estimator, .dots = inputCheck$arguments,
-                                   labels = labels[inSample], verbose = FALSE,
-                                   weighted = weighted, signed = signed, memorysaver = TRUE)
-        }))
-        if (is(res, "try-error")) {
-          if (tryCount == tryLimit)
-            stop("Maximum number of errors in bootstraps reached")
-          tryCount <- tryCount + 1
-        }
-        else {
-          break
-        }
-      }
-      return(res)
-    }, warning=function(w) w)
-
-    # if aborted
-    if (inherits(bootResults, "warning")) {
-      if (bootResults$message == gettext("progress function failed: Cancelled by callback")) {
-        return()
-      }
-    }
-  }
-
-
-  if (verbose) {
-    message("Computing statistics...")
-  }
-  statTableOrig <- bootnet:::statTable(sampleResult, name = "sample",
-                                       alpha = alpha, computeCentrality = computeCentrality,
-                                       statistics = statistics, directed = directed)
-  if (nCores == 1) {
-    if (verbose) {
-      pb <- txtProgressBar(0, nBoots, style = 3)
-    }
-    statTableBoots <- vector("list", nBoots)
-    for (b in seq_len(nBoots)) {
-      statTableBoots[[b]] <- bootnet:::statTable(bootResults[[b]],
-                                                 name = paste("boot", b), alpha = alpha, computeCentrality = computeCentrality,
-                                                 statistics = statistics, directed = directed)
-      progressbarTick()
-      if (verbose) {
-        setTxtProgressBar(pb, b)
-      }
-    }
-    if (verbose) {
-      close(pb)
-    }
-  }
-  else {
-
-    objToExport <- c("bootResults", "alpha", "computeCentrality",
-                     "statistics", "directed")
-    snow::clusterExport(cl = cl, list = objToExport, envir = environment())
-    statTableBoots <- tryCatch(foreach::foreach(
-      b = seq_len(nBoots),
-      .options.snow=setup$progress,
-      .inorder = FALSE,
-      # .export = objToExport,
-      .packages = c("bootnet"),
-      .verbose = TRUE
-    ) %dopar% {
-      bootnet:::statTable(bootResults[[b]], name = paste("boot", b),
-                          alpha = alpha, computeCentrality = computeCentrality,
-                          statistics = statistics, directed = directed)
-    }, warning=function(w) w)
-
-    # if aborted
-    if (inherits(bootResults, "warning")) {
-      if (bootResults$message == "progress function failed: Cancelled by callback") {
-        return()
-      }
-    }
-    parallel::stopCluster(cl)
-  }
-  Result <- list(sampleTable = dplyr::ungroup(statTableOrig),
-                 bootTable = dplyr::ungroup(dplyr::bind_rows(statTableBoots)),
-                 sample = sampleResult, boots = bootResults, type = type,
-                 sampleSize = Np)
-  class(Result) <- "bootnet"
-  return(Result)
-}
 
 # TODO: there is no init anymore. Does the remark below still apply???
 # direct copy of bootnet:::getRefs. Otherwise, bootnet namespace gets loaded on init which takes pretty long.

--- a/inst/qml/NetworkAnalysis.qml
+++ b/inst/qml/NetworkAnalysis.qml
@@ -44,7 +44,7 @@ Form
 			{ value: "IsingFit",		label: "IsingFit"			},
 			{ value: "IsingSampler",	label: "IsingSampler"		},
 			{ value: "huge",			label: qsTr("huge")			},
-			{ value: "adalasso",		label: "adalasso"			},
+//			{ value: "adalasso",		label: "adalasso"			},	// no longer available due to removal of parcor from CRAN
 			{ value: "mgm",				label: "mgm"				}
 		]
 	}
@@ -131,7 +131,7 @@ Form
 		{
 			name: "criterion"
 			title: qsTr("Criterion")
-			visible: [5, 7].includes(estimator.currentIndex)
+			visible: [5, 6].includes(estimator.currentIndex)
 			RadioButton { value: "ebic";	label: qsTr("EBIC"); checked: true	}
 			RadioButton { value: "ric";		label: qsTr("RIC")					}
 			RadioButton { value: "stars";	label: qsTr("STARS")				}
@@ -142,7 +142,7 @@ Form
 		{
 			name: "rule"
 			title: qsTr("Rule")
-			visible: [3, 7].includes(estimator.currentIndex)
+			visible: [3, 6].includes(estimator.currentIndex)
 			RadioButton { value: "and";	label: qsTr("AND"); checked: true	}
 			RadioButton { value: "or";	label: qsTr("OR")					}
 		}
@@ -205,7 +205,7 @@ Form
 
 		VariablesForm
 		{
-			visible: [7].includes(estimator.currentIndex)
+			visible: [6].includes(estimator.currentIndex)
 			AvailableVariablesList
 			{
 				title: qsTr("Variables in network")

--- a/tests/figs/NetworkAnalysis/networkanalysis-cor-bootstrapped-edges.svg
+++ b/tests/figs/NetworkAnalysis/networkanalysis-cor-bootstrapped-edges.svg
@@ -19,59 +19,59 @@
   </clipPath>
 </defs>
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,500.36 714.52,500.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,453.24 714.52,453.24 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,406.12 714.52,406.12 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,358.99 714.52,358.99 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,514.16 714.52,514.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,463.59 714.52,463.59 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,413.01 714.52,413.01 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,362.44 714.52,362.44 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='50.37,311.87 714.52,311.87 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,264.75 714.52,264.75 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,217.62 714.52,217.62 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,170.50 714.52,170.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,123.38 714.52,123.38 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,261.30 714.52,261.30 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,210.73 714.52,210.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,160.16 714.52,160.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,109.58 714.52,109.58 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='148.87,545.13 148.87,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='267.71,545.13 267.71,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='386.55,545.13 386.55,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='505.39,545.13 505.39,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='624.23,545.13 624.23,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,523.93 714.52,523.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,476.80 714.52,476.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,429.68 714.52,429.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,382.56 714.52,382.56 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,335.43 714.52,335.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,288.31 714.52,288.31 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,241.19 714.52,241.19 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,194.06 714.52,194.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,146.94 714.52,146.94 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,99.82 714.52,99.82 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,539.44 714.52,539.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,488.87 714.52,488.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,438.30 714.52,438.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,387.73 714.52,387.73 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,337.16 714.52,337.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,286.58 714.52,286.58 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,236.01 714.52,236.01 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,185.44 714.52,185.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,134.87 714.52,134.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,84.30 714.52,84.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='89.45,545.13 89.45,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='208.29,545.13 208.29,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='327.13,545.13 327.13,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='445.97,545.13 445.97,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='564.81,545.13 564.81,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='683.65,545.13 683.65,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polygon points='80.56,523.93 112.17,476.80 165.56,429.68 236.33,382.56 517.51,335.43 535.46,288.31 555.12,241.19 576.48,194.06 654.43,146.94 662.65,99.82 684.33,99.82 677.63,146.94 612.17,194.06 586.82,241.19 556.95,288.31 549.83,335.43 250.97,382.56 190.90,429.68 124.02,476.80 88.69,523.93 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='84.62,523.93 118.09,476.80 178.23,429.68 243.65,382.56 533.67,335.43 546.20,288.31 570.97,241.19 594.32,194.06 666.03,146.94 673.49,99.82 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='84.43,523.93 135.48,476.80 191.74,429.68 222.89,382.56 538.23,335.43 558.69,288.31 569.60,241.19 593.83,194.06 657.19,146.94 667.52,99.82 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='84.43' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='135.48' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='191.74' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='222.89' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='538.23' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='558.69' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='569.60' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='593.83' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='657.19' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='667.52' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='84.62' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='118.09' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='178.23' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='243.65' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='533.67' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='546.20' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='570.97' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='594.32' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='666.03' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='673.49' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polygon points='80.56,539.44 112.17,488.87 165.56,438.30 236.33,387.73 517.51,337.16 535.46,286.58 555.12,236.01 576.48,185.44 654.43,134.87 662.65,84.30 684.33,84.30 677.63,134.87 612.17,185.44 586.82,236.01 556.95,286.58 549.83,337.16 250.97,387.73 190.90,438.30 124.02,488.87 88.69,539.44 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='84.62,539.44 118.09,488.87 178.23,438.30 243.65,387.73 533.67,337.16 546.20,286.58 570.97,236.01 594.32,185.44 666.03,134.87 673.49,84.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='84.43,539.44 135.48,488.87 191.74,438.30 222.89,387.73 538.23,337.16 558.69,286.58 569.60,236.01 593.83,185.44 657.19,134.87 667.52,84.30 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='84.43' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='135.48' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='191.74' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='222.89' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='538.23' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='558.69' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='569.60' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='593.83' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='657.19' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='667.52' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='84.62' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='118.09' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='178.23' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='243.65' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='533.67' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='546.20' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='570.97' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='594.32' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='666.03' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='673.49' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
@@ -102,26 +102,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='439.86' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.2</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='558.70' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.4</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='677.55' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.6</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='526.95' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='479.83' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='432.70' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='385.58' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='338.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='291.33' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='244.21' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='197.09' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='149.96' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='102.84' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
-<polyline points='47.63,523.93 50.37,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,476.80 50.37,476.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,429.68 50.37,429.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,382.56 50.37,382.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,335.43 50.37,335.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,288.31 50.37,288.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,241.19 50.37,241.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,194.06 50.37,194.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,146.94 50.37,146.94 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,99.82 50.37,99.82 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='542.47' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='491.90' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='441.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='390.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='340.18' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='289.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='239.04' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='188.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='137.89' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='87.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
+<polyline points='47.63,539.44 50.37,539.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,488.87 50.37,488.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,438.30 50.37,438.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,387.73 50.37,387.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,337.16 50.37,337.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,286.58 50.37,286.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,236.01 50.37,236.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,185.44 50.37,185.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,134.87 50.37,134.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,84.30 50.37,84.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='302.77' y='22.77' width='159.34' height='28.24' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='313.73' y='28.25' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <circle cx='322.37' cy='36.89' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />

--- a/tests/figs/NetworkAnalysis/networkanalysis-ebicglasso-bootstrapped-edges.svg
+++ b/tests/figs/NetworkAnalysis/networkanalysis-ebicglasso-bootstrapped-edges.svg
@@ -19,56 +19,56 @@
   </clipPath>
 </defs>
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,500.36 714.52,500.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,453.24 714.52,453.24 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,406.12 714.52,406.12 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,358.99 714.52,358.99 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,514.16 714.52,514.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,463.59 714.52,463.59 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,413.01 714.52,413.01 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,362.44 714.52,362.44 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='50.37,311.87 714.52,311.87 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,264.75 714.52,264.75 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,217.62 714.52,217.62 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,170.50 714.52,170.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,123.38 714.52,123.38 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,261.30 714.52,261.30 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,210.73 714.52,210.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,160.16 714.52,160.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,109.58 714.52,109.58 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='61.91,545.13 61.91,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='239.03,545.13 239.03,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='416.14,545.13 416.14,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='593.25,545.13 593.25,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,523.93 714.52,523.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,476.80 714.52,476.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,429.68 714.52,429.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,382.56 714.52,382.56 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,335.43 714.52,335.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,288.31 714.52,288.31 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,241.19 714.52,241.19 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,194.06 714.52,194.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,146.94 714.52,146.94 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,99.82 714.52,99.82 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,539.44 714.52,539.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,488.87 714.52,488.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,438.30 714.52,438.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,387.73 714.52,387.73 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,337.16 714.52,337.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,286.58 714.52,286.58 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,236.01 714.52,236.01 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,185.44 714.52,185.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,134.87 714.52,134.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,84.30 714.52,84.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='150.47,545.13 150.47,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='327.58,545.13 327.58,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='504.69,545.13 504.69,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='681.81,545.13 681.81,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polygon points='89.71,523.93 199.24,476.80 303.19,429.68 365.92,382.56 424.98,335.43 441.99,288.31 485.67,241.19 466.98,194.06 610.36,146.94 681.83,99.82 684.33,99.82 619.77,146.94 475.25,194.06 509.15,241.19 467.28,288.31 439.24,335.43 367.90,382.56 320.17,429.68 204.83,476.80 96.90,523.93 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='93.31,523.93 202.04,476.80 311.68,429.68 366.91,382.56 432.11,335.43 454.63,288.31 497.41,241.19 471.11,194.06 615.06,146.94 683.08,99.82 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='80.56,523.93 229.29,476.80 327.58,429.68 327.58,382.56 438.68,335.43 465.70,288.31 481.84,241.19 487.47,194.06 602.63,146.94 679.61,99.82 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='80.56' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='229.29' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='327.58' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='327.58' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='438.68' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='465.70' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='481.84' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='487.47' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='602.63' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='679.61' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='93.31' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='202.04' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='311.68' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='366.91' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='432.11' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='454.63' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='497.41' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='471.11' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='615.06' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='683.08' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polygon points='89.71,539.44 199.24,488.87 303.19,438.30 365.92,387.73 424.98,337.16 441.99,286.58 485.67,236.01 466.98,185.44 610.36,134.87 681.83,84.30 684.33,84.30 619.77,134.87 475.25,185.44 509.15,236.01 467.28,286.58 439.24,337.16 367.90,387.73 320.17,438.30 204.83,488.87 96.90,539.44 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='93.31,539.44 202.04,488.87 311.68,438.30 366.91,387.73 432.11,337.16 454.63,286.58 497.41,236.01 471.11,185.44 615.06,134.87 683.08,84.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='80.56,539.44 229.29,488.87 327.58,438.30 327.58,387.73 438.68,337.16 465.70,286.58 481.84,236.01 487.47,185.44 602.63,134.87 679.61,84.30 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='80.56' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='229.29' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='327.58' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='327.58' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='438.68' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='465.70' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='481.84' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='487.47' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='602.63' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='679.61' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='93.31' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='202.04' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='311.68' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='366.91' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='432.11' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='454.63' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='497.41' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='471.11' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='615.06' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='683.08' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
@@ -95,26 +95,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='321.47' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='498.58' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.2</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='675.70' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='526.95' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='479.83' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='432.70' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='385.58' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='338.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='291.33' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='244.21' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='197.09' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='149.96' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='102.84' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
-<polyline points='47.63,523.93 50.37,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,476.80 50.37,476.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,429.68 50.37,429.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,382.56 50.37,382.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,335.43 50.37,335.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,288.31 50.37,288.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,241.19 50.37,241.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,194.06 50.37,194.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,146.94 50.37,146.94 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,99.82 50.37,99.82 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='542.47' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='491.90' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='441.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='390.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='340.18' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='289.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='239.04' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='188.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='137.89' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='87.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
+<polyline points='47.63,539.44 50.37,539.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,488.87 50.37,488.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,438.30 50.37,438.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,387.73 50.37,387.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,337.16 50.37,337.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,286.58 50.37,286.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,236.01 50.37,236.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,185.44 50.37,185.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,134.87 50.37,134.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,84.30 50.37,84.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='302.77' y='22.77' width='159.34' height='28.24' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='313.73' y='28.25' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <circle cx='322.37' cy='36.89' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />

--- a/tests/figs/NetworkAnalysis/networkanalysis-huge-bootstrapped-edges.svg
+++ b/tests/figs/NetworkAnalysis/networkanalysis-huge-bootstrapped-edges.svg
@@ -19,54 +19,54 @@
   </clipPath>
 </defs>
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,500.36 714.52,500.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,453.24 714.52,453.24 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,406.12 714.52,406.12 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,358.99 714.52,358.99 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,514.16 714.52,514.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,463.59 714.52,463.59 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,413.01 714.52,413.01 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,362.44 714.52,362.44 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='50.37,311.87 714.52,311.87 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,264.75 714.52,264.75 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,217.62 714.52,217.62 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,170.50 714.52,170.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,123.38 714.52,123.38 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,261.30 714.52,261.30 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,210.73 714.52,210.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,160.16 714.52,160.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,109.58 714.52,109.58 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='224.39,545.13 224.39,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='420.45,545.13 420.45,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='616.51,545.13 616.51,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,523.93 714.52,523.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,476.80 714.52,476.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,429.68 714.52,429.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,382.56 714.52,382.56 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,335.43 714.52,335.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,288.31 714.52,288.31 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,241.19 714.52,241.19 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,194.06 714.52,194.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,146.94 714.52,146.94 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,99.82 714.52,99.82 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,539.44 714.52,539.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,488.87 714.52,488.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,438.30 714.52,438.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,387.73 714.52,387.73 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,337.16 714.52,337.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,286.58 714.52,286.58 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,236.01 714.52,236.01 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,185.44 714.52,185.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,134.87 714.52,134.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,84.30 714.52,84.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='126.37,545.13 126.37,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='322.42,545.13 322.42,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='518.48,545.13 518.48,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polygon points='86.37,523.93 192.12,476.80 284.18,429.68 344.34,382.56 424.08,335.43 451.65,288.31 466.43,241.19 489.69,194.06 616.26,146.94 683.82,99.82 684.33,99.82 628.25,146.94 512.24,194.06 470.06,241.19 473.64,288.31 442.77,335.43 349.68,382.56 301.95,429.68 196.08,476.80 101.05,523.93 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='93.71,523.93 194.10,476.80 293.06,429.68 347.01,382.56 433.43,335.43 462.65,288.31 468.25,241.19 500.96,194.06 622.26,146.94 684.07,99.82 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='80.56,523.93 212.44,476.80 310.23,429.68 322.42,382.56 441.31,335.43 471.58,288.31 483.82,241.19 489.54,194.06 607.72,146.94 681.10,99.82 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='80.56' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='212.44' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='310.23' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='322.42' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='441.31' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='471.58' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='483.82' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='489.54' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='607.72' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='681.10' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='93.71' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='194.10' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='293.06' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='347.01' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='433.43' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='462.65' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='468.25' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='500.96' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='622.26' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='684.07' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polygon points='86.37,539.44 192.12,488.87 284.18,438.30 344.34,387.73 424.08,337.16 451.65,286.58 466.43,236.01 489.69,185.44 616.26,134.87 683.82,84.30 684.33,84.30 628.25,134.87 512.24,185.44 470.06,236.01 473.64,286.58 442.77,337.16 349.68,387.73 301.95,438.30 196.08,488.87 101.05,539.44 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='93.71,539.44 194.10,488.87 293.06,438.30 347.01,387.73 433.43,337.16 462.65,286.58 468.25,236.01 500.96,185.44 622.26,134.87 684.07,84.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='80.56,539.44 212.44,488.87 310.23,438.30 322.42,387.73 441.31,337.16 471.58,286.58 483.82,236.01 489.54,185.44 607.72,134.87 681.10,84.30 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='80.56' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='212.44' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='310.23' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='322.42' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='441.31' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='471.58' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='483.82' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='489.54' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='607.72' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='681.10' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='93.71' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='194.10' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='293.06' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='347.01' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='433.43' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='462.65' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='468.25' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='500.96' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='622.26' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='684.07' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
@@ -91,26 +91,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='118.80' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='15.14px' lengthAdjust='spacingAndGlyphs'>-0.2</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='316.31' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='512.37' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='526.95' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='479.83' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='432.70' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='385.58' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='338.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='291.33' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='244.21' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='197.09' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='149.96' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='102.84' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
-<polyline points='47.63,523.93 50.37,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,476.80 50.37,476.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,429.68 50.37,429.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,382.56 50.37,382.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,335.43 50.37,335.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,288.31 50.37,288.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,241.19 50.37,241.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,194.06 50.37,194.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,146.94 50.37,146.94 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,99.82 50.37,99.82 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='542.47' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='491.90' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='441.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='390.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='340.18' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='289.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='239.04' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='188.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='137.89' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='87.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
+<polyline points='47.63,539.44 50.37,539.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,488.87 50.37,488.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,438.30 50.37,438.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,387.73 50.37,387.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,337.16 50.37,337.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,286.58 50.37,286.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,236.01 50.37,236.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,185.44 50.37,185.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,134.87 50.37,134.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,84.30 50.37,84.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='302.77' y='22.77' width='159.34' height='28.24' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='313.73' y='28.25' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <circle cx='322.37' cy='36.89' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />

--- a/tests/figs/NetworkAnalysis/networkanalysis-isingfit-bootstrapped-edges.svg
+++ b/tests/figs/NetworkAnalysis/networkanalysis-isingfit-bootstrapped-edges.svg
@@ -19,54 +19,54 @@
   </clipPath>
 </defs>
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,500.36 714.52,500.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,453.24 714.52,453.24 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,406.12 714.52,406.12 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,358.99 714.52,358.99 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,514.16 714.52,514.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,463.59 714.52,463.59 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,413.01 714.52,413.01 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,362.44 714.52,362.44 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='50.37,311.87 714.52,311.87 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,264.75 714.52,264.75 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,217.62 714.52,217.62 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,170.50 714.52,170.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,123.38 714.52,123.38 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,261.30 714.52,261.30 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,210.73 714.52,210.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,160.16 714.52,160.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,109.58 714.52,109.58 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='238.84,545.13 238.84,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='455.68,545.13 455.68,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='672.51,545.13 672.51,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,523.93 714.52,523.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,476.80 714.52,476.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,429.68 714.52,429.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,382.56 714.52,382.56 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,335.43 714.52,335.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,288.31 714.52,288.31 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,241.19 714.52,241.19 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,194.06 714.52,194.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,146.94 714.52,146.94 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,99.82 714.52,99.82 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,539.44 714.52,539.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,488.87 714.52,488.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,438.30 714.52,438.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,387.73 714.52,387.73 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,337.16 714.52,337.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,286.58 714.52,286.58 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,236.01 714.52,236.01 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,185.44 714.52,185.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,134.87 714.52,134.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,84.30 714.52,84.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='130.42,545.13 130.42,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='347.26,545.13 347.26,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='564.10,545.13 564.10,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polygon points='104.21,523.93 180.57,476.80 272.99,429.68 347.26,382.56 414.96,335.43 441.44,288.31 514.72,241.19 502.68,194.06 601.95,146.94 673.40,99.82 684.33,99.82 654.23,146.94 504.35,194.06 545.06,241.19 502.70,288.31 430.79,335.43 347.26,382.56 285.58,429.68 201.96,476.80 105.21,523.93 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='104.71,523.93 191.27,476.80 279.29,429.68 347.26,382.56 422.87,335.43 472.07,288.31 529.89,241.19 503.51,194.06 628.09,146.94 678.87,99.82 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='80.56,523.93 222.84,476.80 282.76,429.68 301.35,382.56 434.85,335.43 489.87,288.31 518.67,241.19 523.47,194.06 609.25,146.94 678.24,99.82 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='80.56' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='222.84' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='282.76' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='301.35' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='434.85' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='489.87' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='518.67' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='523.47' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='609.25' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='678.24' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='104.71' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='191.27' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='279.29' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='347.26' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='422.87' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='472.07' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='529.89' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='503.51' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='628.09' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='678.87' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polygon points='104.21,539.44 180.57,488.87 272.99,438.30 347.26,387.73 414.96,337.16 441.44,286.58 514.72,236.01 502.68,185.44 601.95,134.87 673.40,84.30 684.33,84.30 654.23,134.87 504.35,185.44 545.06,236.01 502.70,286.58 430.79,337.16 347.26,387.73 285.58,438.30 201.96,488.87 105.21,539.44 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='104.71,539.44 191.27,488.87 279.29,438.30 347.26,387.73 422.87,337.16 472.07,286.58 529.89,236.01 503.51,185.44 628.09,134.87 678.87,84.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='80.56,539.44 222.84,488.87 282.76,438.30 301.35,387.73 434.85,337.16 489.87,286.58 518.67,236.01 523.47,185.44 609.25,134.87 678.24,84.30 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='80.56' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='222.84' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='282.76' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='301.35' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='434.85' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='489.87' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='518.67' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='523.47' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='609.25' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='678.24' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='104.71' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='191.27' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='279.29' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='347.26' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='422.87' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='472.07' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='529.89' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='503.51' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='628.09' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='678.87' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
@@ -91,26 +91,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='126.52' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='7.81px' lengthAdjust='spacingAndGlyphs'>-1</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='344.81' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='561.65' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='4.89px' lengthAdjust='spacingAndGlyphs'>1</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='526.95' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='479.83' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='432.70' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='385.58' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='338.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='291.33' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='244.21' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='197.09' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='149.96' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='102.84' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
-<polyline points='47.63,523.93 50.37,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,476.80 50.37,476.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,429.68 50.37,429.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,382.56 50.37,382.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,335.43 50.37,335.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,288.31 50.37,288.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,241.19 50.37,241.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,194.06 50.37,194.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,146.94 50.37,146.94 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,99.82 50.37,99.82 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='542.47' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='491.90' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='441.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='390.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='340.18' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='289.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='239.04' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='188.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='137.89' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='87.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
+<polyline points='47.63,539.44 50.37,539.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,488.87 50.37,488.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,438.30 50.37,438.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,387.73 50.37,387.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,337.16 50.37,337.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,286.58 50.37,286.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,236.01 50.37,236.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,185.44 50.37,185.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,134.87 50.37,134.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,84.30 50.37,84.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='302.77' y='22.77' width='159.34' height='28.24' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='313.73' y='28.25' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <circle cx='322.37' cy='36.89' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />

--- a/tests/figs/NetworkAnalysis/networkanalysis-pcor-bootstrapped-edges.svg
+++ b/tests/figs/NetworkAnalysis/networkanalysis-pcor-bootstrapped-edges.svg
@@ -19,56 +19,56 @@
   </clipPath>
 </defs>
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,500.36 714.52,500.36 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,453.24 714.52,453.24 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,406.12 714.52,406.12 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,358.99 714.52,358.99 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,514.16 714.52,514.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,463.59 714.52,463.59 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,413.01 714.52,413.01 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,362.44 714.52,362.44 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='50.37,311.87 714.52,311.87 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,264.75 714.52,264.75 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,217.62 714.52,217.62 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,170.50 714.52,170.50 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,123.38 714.52,123.38 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,261.30 714.52,261.30 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,210.73 714.52,210.73 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,160.16 714.52,160.16 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,109.58 714.52,109.58 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='66.35,545.13 66.35,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='241.61,545.13 241.61,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='416.86,545.13 416.86,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='592.12,545.13 592.12,78.61 ' style='stroke-width: 0.53; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,523.93 714.52,523.93 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,476.80 714.52,476.80 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,429.68 714.52,429.68 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,382.56 714.52,382.56 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,335.43 714.52,335.43 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,288.31 714.52,288.31 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,241.19 714.52,241.19 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,194.06 714.52,194.06 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,146.94 714.52,146.94 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='50.37,99.82 714.52,99.82 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,539.44 714.52,539.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,488.87 714.52,488.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,438.30 714.52,438.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,387.73 714.52,387.73 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,337.16 714.52,337.16 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,286.58 714.52,286.58 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,236.01 714.52,236.01 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,185.44 714.52,185.44 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,134.87 714.52,134.87 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='50.37,84.30 714.52,84.30 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='153.98,545.13 153.98,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='329.23,545.13 329.23,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='504.49,545.13 504.49,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <polyline points='679.74,545.13 679.74,78.61 ' style='stroke-width: 1.07; stroke: #EBEBEB; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polygon points='89.93,523.93 199.46,476.80 303.11,429.68 378.53,382.56 426.70,335.43 441.87,288.31 488.18,241.19 471.44,194.06 609.31,146.94 681.75,99.82 684.33,99.82 618.60,146.94 479.67,194.06 511.62,241.19 466.70,288.31 440.83,335.43 381.92,382.56 320.15,429.68 204.56,476.80 96.99,523.93 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='93.46,523.93 202.01,476.80 311.63,429.68 380.23,382.56 433.77,335.43 454.28,288.31 499.90,241.19 475.56,194.06 613.95,146.94 683.04,99.82 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<polyline points='80.56,523.93 229.15,476.80 328.09,429.68 340.41,382.56 440.06,335.43 465.61,288.31 483.89,241.19 491.73,194.06 601.56,146.94 679.81,99.82 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='80.56' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='229.15' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='328.09' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='340.41' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='440.06' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='465.61' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='483.89' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='491.73' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='601.56' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='679.81' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='93.46' cy='523.93' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='202.01' cy='476.80' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='311.63' cy='429.68' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='380.23' cy='382.56' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='433.77' cy='335.43' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='454.28' cy='288.31' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='499.90' cy='241.19' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='475.56' cy='194.06' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='613.95' cy='146.94' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
-<circle cx='683.04' cy='99.82' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polygon points='89.93,539.44 199.46,488.87 303.11,438.30 378.53,387.73 426.70,337.16 441.87,286.58 488.18,236.01 471.44,185.44 609.31,134.87 681.75,84.30 684.33,84.30 618.60,134.87 479.67,185.44 511.62,236.01 466.70,286.58 440.83,337.16 381.92,387.73 320.15,438.30 204.56,488.87 96.99,539.44 ' style='stroke-width: 1.07; stroke: none; fill: #000000; fill-opacity: 0.10;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='93.46,539.44 202.01,488.87 311.63,438.30 380.23,387.73 433.77,337.16 454.28,286.58 499.90,236.01 475.56,185.44 613.95,134.87 683.04,84.30 ' style='stroke-width: 1.07; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<polyline points='80.56,539.44 229.15,488.87 328.09,438.30 340.41,387.73 440.06,337.16 465.61,286.58 483.89,236.01 491.73,185.44 601.56,134.87 679.81,84.30 ' style='stroke-width: 2.13; stroke: #8B0000; stroke-linecap: butt;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='80.56' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='229.15' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='328.09' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='340.41' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='440.06' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='465.61' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='483.89' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='491.73' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='601.56' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='679.81' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #8B0000; stroke-opacity: 0.55; fill: #8B0000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='93.46' cy='539.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='202.01' cy='488.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='311.63' cy='438.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='380.23' cy='387.73' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='433.77' cy='337.16' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='454.28' cy='286.58' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='499.90' cy='236.01' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='475.56' cy='185.44' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='613.95' cy='134.87' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
+<circle cx='683.04' cy='84.30' r='1.95pt' style='stroke-width: 0.71; stroke: #000000; stroke-opacity: 0.55; fill: #000000; fill-opacity: 0.55;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <rect x='50.37' y='78.61' width='664.15' height='466.52' style='stroke-width: 1.07; stroke: #333333;' clip-path='url(#cpNTAuMzd8NzE0LjUyfDU0NS4xM3w3OC42MQ==)' />
 <defs>
   <clipPath id='cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA='>
@@ -95,26 +95,26 @@
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='323.13' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.0</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='498.38' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.2</text></g>
 <g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='673.63' y='556.11' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='12.22px' lengthAdjust='spacingAndGlyphs'>0.4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='526.95' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='479.83' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='432.70' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='385.58' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='338.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='291.33' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='244.21' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='197.09' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='149.96' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
-<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='102.84' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
-<polyline points='47.63,523.93 50.37,523.93 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,476.80 50.37,476.80 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,429.68 50.37,429.68 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,382.56 50.37,382.56 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,335.43 50.37,335.43 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,288.31 50.37,288.31 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,241.19 50.37,241.19 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,194.06 50.37,194.06 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,146.94 50.37,146.94 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
-<polyline points='47.63,99.82 50.37,99.82 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='542.47' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A2</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='491.90' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='441.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='390.75' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A1--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='340.18' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A4--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='289.61' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A5</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='239.04' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='188.46' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A4</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='137.89' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A2--A3</text></g>
+<g clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)'><text x='18.06' y='87.32' style='font-size: 8.80px; fill: #4D4D4D; font-family: Liberation Sans;' textLength='27.38px' lengthAdjust='spacingAndGlyphs'>A3--A5</text></g>
+<polyline points='47.63,539.44 50.37,539.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,488.87 50.37,488.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,438.30 50.37,438.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,387.73 50.37,387.73 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,337.16 50.37,337.16 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,286.58 50.37,286.58 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,236.01 50.37,236.01 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,185.44 50.37,185.44 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,134.87 50.37,134.87 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
+<polyline points='47.63,84.30 50.37,84.30 ' style='stroke-width: 1.07; stroke: #333333; stroke-linecap: butt;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='302.77' y='22.77' width='159.34' height='28.24' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <rect x='313.73' y='28.25' width='17.28' height='17.28' style='stroke-width: 1.07; stroke: none; fill: #FFFFFF;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />
 <circle cx='322.37' cy='36.89' r='1.95pt' style='stroke-width: 0.71; fill: #000000;' clip-path='url(#cpMC4wMHw3MjAuMDB8NTc2LjAwfDAuMDA=)' />

--- a/tests/figs/deps.txt
+++ b/tests/figs/deps.txt
@@ -1,3 +1,3 @@
 - vdiffr-svg-engine: 1.0
-- vdiffr: 0.3.1
-- freetypeharfbuzz: 0.2.5
+- vdiffr: 0.3.3
+- freetypeharfbuzz: 0.2.6

--- a/tests/figs/jasp-deps.txt
+++ b/tests/figs/jasp-deps.txt
@@ -1,1 +1,1 @@
-- jaspGraphs: 0.5.1
+- jaspGraphs: 0.5.2.3

--- a/tests/testthat/test-networkanalysis.R
+++ b/tests/testthat/test-networkanalysis.R
@@ -73,7 +73,7 @@ file <- "networkResults.rds"
 #     return(lapply(x, clearEverythingButData))
 #   }
 # }
-# 
+#
 # results <- vector("list", length(estimators))
 # names(results) <- names(estimators)
 # for (e in estimators) {
@@ -85,67 +85,82 @@ file <- "networkResults.rds"
 # saveRDS(results, file = file)
 storedResults <- readRDS(file)
 
+skip_if_adalasso <- function(estimator) {
+  skip_if(estimator == "adalasso", r"(dependency "parcor" was removed from CRAN so this test is skipped)")
+}
+
 for (estimator in estimators) {
-  
+
+
   options$estimator <- estimator
   set.seed(1)
+  # debugonce(jaspNetwork:::.networkAnalysiscom)
   results <- jaspTools::runAnalysis("NetworkAnalysis", "BFI Network.csv", options)
 
   test_that(paste0(estimator, ": Centrality measures per variable table results match"), {
+    skip_if_adalasso(estimator)
     table    <- results                   [["results"]][["mainContainer"]][["collection"]][["mainContainer_centralityTable"]][["data"]]
     oldTable <- storedResults[[estimator]][["results"]][["mainContainer"]][["collection"]][["mainContainer_centralityTable"]][["data"]]
     jaspTools::expect_equal_tables(table, jaspTools:::collapseTestTable(oldTable))
   })
-  
+
   test_that(paste0(estimator, ": Clustering measures per variable table results match"), {
+    skip_if_adalasso(estimator)
     table    <- results                   [["results"]][["mainContainer"]][["collection"]][["mainContainer_clusteringTable"]][["data"]]
     oldTable <- storedResults[[estimator]][["results"]][["mainContainer"]][["collection"]][["mainContainer_clusteringTable"]][["data"]]
     jaspTools::expect_equal_tables(table, jaspTools:::collapseTestTable(oldTable))
   })
-  
+
   test_that(paste0(estimator, ": Summary of Network table results match"), {
+    skip_if_adalasso(estimator)
     table    <- results                   [["results"]][["mainContainer"]][["collection"]][["mainContainer_generalTable"]][["data"]]
     oldTable <- storedResults[[estimator]][["results"]][["mainContainer"]][["collection"]][["mainContainer_generalTable"]][["data"]]
     jaspTools::expect_equal_tables(table, jaspTools:::collapseTestTable(oldTable))
   })
-  
+
   test_that(paste0(estimator, ": Weights matrix table results match"), {
+    skip_if_adalasso(estimator)
     table    <- results                   [["results"]][["mainContainer"]][["collection"]][["mainContainer_weightsTable"]][["data"]]
     oldTable <- storedResults[[estimator]][["results"]][["mainContainer"]][["collection"]][["mainContainer_weightsTable"]][["data"]]
     jaspTools::expect_equal_tables(table, jaspTools:::collapseTestTable(oldTable))
   })
-  
+
   test_that(paste0(estimator, ": Bootstrapped edge plot matches"), {
     if (estimator == "IsingSampler")
       skip("Cannot reliably test Bootstrapped edge plot for IsingSampler")
+    skip_if_adalasso(estimator)
     plotName <- results[["results"]][["mainContainer"]][["collection"]][["mainContainer_bootstrapContainer"]][["collection"]][["mainContainer_bootstrapContainer_EdgeStabilityPlots"]][["collection"]][["mainContainer_bootstrapContainer_EdgeStabilityPlots_Network"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     jaspTools::expect_equal_plots(testPlot, paste0(estimator, "-bootstrapped-edges"), dir="NetworkAnalysis")
   })
-  
+
   test_that(paste0(estimator, ": Bootstrapped centrality plot matches"), {
+    skip_if_adalasso(estimator)
     plotName <- results[["results"]][["mainContainer"]][["collection"]][["mainContainer_bootstrapContainer"]][["collection"]][["mainContainer_bootstrapContainer_StatisticsCentralityPlots"]][["collection"]][["mainContainer_bootstrapContainer_StatisticsCentralityPlots_Network"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     jaspTools::expect_equal_plots(testPlot, paste0(estimator, "-bootstrapped-centrality"), dir="NetworkAnalysis")
   })
-  
+
   test_that(paste0(estimator, ": Centrality Plot matches"), {
     skip("Cannot reliably test Centrality Plots")
+    skip_if_adalasso(estimator)
     plotName <- results[["results"]][["mainContainer"]][["collection"]][["mainContainer_plotContainer"]][["collection"]][["mainContainer_plotContainer_centralityPlot"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     jaspTools::expect_equal_plots(testPlot, paste0(estimator, "-centrality-plot"), dir="NetworkAnalysis")
   })
-  
+
   test_that(paste0(estimator, ": Clustering Plot matches"), {
     skip("Cannot reliably test Clustering Plots")
+    skip_if_adalasso(estimator)
     plotName <- results[["results"]][["mainContainer"]][["collection"]][["mainContainer_plotContainer"]][["collection"]][["mainContainer_plotContainer_clusteringPlot"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     jaspTools::expect_equal_plots(testPlot, paste0(estimator, "-clustering-plot"), dir="NetworkAnalysis")
   })
-  
+
   test_that(paste0(estimator, ": Network plot matches"), {
     if (estimator == "IsingSampler")
       skip("Cannot reliably test Network plot for IsingSampler")
+    skip_if_adalasso(estimator)
     plotName <- results[["results"]][["mainContainer"]][["collection"]][["mainContainer_plotContainer"]][["collection"]][["mainContainer_plotContainer_networkPlotContainer"]][["collection"]][["mainContainer_plotContainer_networkPlotContainer_Network"]][["data"]]
     testPlot <- results[["state"]][["figures"]][[plotName]][["obj"]]
     jaspTools::expect_equal_plots(testPlot, paste0(estimator, "-network-plot"), dir="NetworkAnalysis")

--- a/tests/testthat/test-networkanalysis.R
+++ b/tests/testthat/test-networkanalysis.R
@@ -94,7 +94,6 @@ for (estimator in estimators) {
 
   options$estimator <- estimator
   set.seed(1)
-  # debugonce(jaspNetwork:::.networkAnalysiscom)
   results <- jaspTools::runAnalysis("NetworkAnalysis", "BFI Network.csv", options)
 
   test_that(paste0(estimator, ": Centrality measures per variable table results match"), {


### PR DESCRIPTION
## Upgrade related
- skip unit tests that require the dependency 'parcor' which has been removed from CRAN and remove this option in qml (adalasso).
- remade multiple figures which changed slightly in a newer bootnet version
- instead of copying the bootnet function and injecting the progress bar, we now temporarily overwrite the `utils::setTxtProgressBar` with `jaspBase:::assignFunctionInPackage`. This is hopefully  less likely to crash when bootnet is updated.
- remade multiple figures which received slight adjustments to the axes (inside bootnet).
    
## Other
- changed `jaspBase:::.suppressGrDevice` into `jaspBase::.suppressGrDevice`.
- now also run tests on Ubuntu
