### PR TITLE
Fix groups specification + hide manual colors

### DIFF
--- a/inst/qml/NetworkAnalysis.qml
+++ b/inst/qml/NetworkAnalysis.qml
@@ -267,11 +267,12 @@ Form
 			placeHolder			: qsTr("New Group")
 			minRows				: 2
 			preferredWidth		: (2 * form.width) / 5
-			enabled				: manualColors.checked
-			rowComponentTitle	: qsTr("Group color")
+			rowComponentTitle	: manualColors.checked ? qsTr("Group color") : ""
 			rowComponent: DropDown
 			{
 				name: "groupColors"
+				enabled: manualColors.checked
+				visible: manualColors.checked
 				values: [
 					{ label: qsTr("red")	, value: "red"		},
 					{ label: qsTr("blue")	, value: "blue"		},

--- a/inst/qml/NetworkAnalysis.qml
+++ b/inst/qml/NetworkAnalysis.qml
@@ -271,7 +271,6 @@ Form
 			rowComponent: DropDown
 			{
 				name: "groupColors"
-				enabled: manualColors.checked
 				visible: manualColors.checked
 				values: [
 					{ label: qsTr("red")	, value: "red"		},


### PR DESCRIPTION
I was attended to this via email, you currently cannot change the groups under graphical options, unless a user wants manual colors:

![image](https://user-images.githubusercontent.com/21319932/154807488-9091aaba-622d-43ff-be1c-5db69e013026.png)

but it shouldn't be necessary to select manual colors in order to add groups.

So I tried, to do just `enabled: manualColors.checked`, but that doesn't seem to work for rowComponents. That's why they are now hidden, in addition to being disabled (which doesn't work). 

@boutinb can you confirm that rowComponents cannot be disabled?

New GUI

`Manual colors` unchecked

![image](https://user-images.githubusercontent.com/21319932/154807626-8447e291-b759-402c-a501-8cd8160c7367.png)

`Manual colors` checked

![image](https://user-images.githubusercontent.com/21319932/154807639-a13a832c-ea0b-4589-9916-c7302b4ec8e8.png)


