### PR TITLE
Always show "Strength" in centrality table and centrality plot

### DIFF
--- a/R/networkanalysis.R
+++ b/R/networkanalysis.R
@@ -295,11 +295,10 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   if (is.null(overTitles))
     overTitles <- gettext("Network") # paste0("Network", 1:nGraphs)
 
-  nameCol3 <- if ("degree" %in% colnames(network[["centrality"]][[1]])[3]) "degree" else "Strength"
   for (i in seq_len(nGraphs)) { # three centrality columns per network
     table$addColumnInfo(name = paste0("betweenness", i),        title = gettext("Betweenness"),        type = "number", overtitle = overTitles[i])
     table$addColumnInfo(name = paste0("closeness", i),          title = gettext("Closeness"),          type = "number", overtitle = overTitles[i])
-    table$addColumnInfo(name = paste0(nameCol3, i),             title = gettext("Strength"),           type = "number", overtitle = overTitles[i])
+    table$addColumnInfo(name = paste0("Strength", i),           title = gettext("Strength"),           type = "number", overtitle = overTitles[i])
     table$addColumnInfo(name = paste0("Expected influence", i), title = gettext("Expected influence"), type = "number", overtitle = overTitles[i])
   }
 
@@ -493,6 +492,14 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
     measuresToFilter <- c("betweenness", "closeness", "degree", "Expected Influence")[measuresToShow]
     long <- subset(long, measure %in% measuresToFilter)
   }
+
+  if (options[["degree"]]) {
+    measureLevels <- levels(long[["measure"]])
+    levels(long[["measure"]]) <- ifelse(measureLevels == "degree", "Strength", measureLevels)
+  }
+
+  # ensure that the first character is capitalized in the text above the subplots so it matches the centrality table
+  levels(long[["measure"]]) <- stringr::str_to_title(levels(long[["measure"]]))
 
   .networkAnalysisMakePlotFromLong(plot, long, options)
 
@@ -1101,7 +1108,8 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
       wmat <- abs(wmat)
 
     directedGraph <- ifelse(base::isSymmetric.matrix(object = wmat, tol = 1e-12), FALSE, TRUE)
-    weightedGraph <- ifelse(all(qgraph::mat2vec(wmat) %in% c(0, 1)), FALSE, TRUE)
+    # Always assume we have a weighted graph, otherwise graphs without any edges are interpreted as unweighted
+    weightedGraph <- TRUE #ifelse(all(qgraph::mat2vec(wmat) %in% c(0, 1)), FALSE, TRUE)
 
     if (directedGraph) {
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/1692

Before we would show "degree" instead of "Strength", but only sometimes. The decision depended on whether the adjacency matrix contained anything besides 0 and 1 because that would imply a weighted graph. And for unweighted graphs, the terminology is "Degree", whereas for weighted graphs it's "Strength". However, the analyses we currently provide should always return a weighted graph, so in practice, you should never see "degree". Nevertheless, you would sometimes see "degree" if you'd have a very weird graph (e.g., one without any edges) because the previous check would incorrectly interpret those adjacency matrices. This PR just always assumes a weighted graph. We can always change this in the future if we want to support unweighted graphs.

There are unfortunately no unit tests because all centrality and clustering plots are skipped due to replicability problems (it's probably a good idea to revisit that at some point).