### PR TITLE
Properly index in the error object when trying to show an error message

### DIFF
--- a/R/networkanalysis.R
+++ b/R/networkanalysis.R
@@ -1574,7 +1574,7 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
   # Unfortunately, these error appear for particular subsets of the data (from cross validation),
   # so it's difficult to traceable particular errors to the complete data.
 
-  errmsg <- .extractErrorMessage(e)
+  errmsg <- .extractErrorMessage(e[["message"]])
   # possibly add other checks here in the future
   dataIssue <- startsWith(errmsg, "y is constant") || endsWith(errmsg, "standardization step")
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/2088

Before:
![image](https://user-images.githubusercontent.com/21319932/231161834-8a2ab564-a77a-47ea-aa0b-19ca1c724943.png)


After:
![image](https://user-images.githubusercontent.com/21319932/231161721-2e5f4a58-c28c-48e5-94b6-4cef57300ab6.png)

I'm assuming that the `:n` part is just a jaspTools artifact.