### PR TITLE
Order the passed column names by the order in the dataset

### DIFF
--- a/R/networkanalysis.R
+++ b/R/networkanalysis.R
@@ -737,7 +737,14 @@ NetworkAnalysis <- function(jaspResults, dataset, options) {
 
   if (length(options[["colorGroupVariables"]]) > 1L) {
 
-    assignedGroup <- vapply(options[["colorGroupVariables"]], `[[`, character(1L), "group")
+    fittedVariablesOrder   <- network[["network"]][[1L]]$labels
+    assignedVariablesOrder <- vapply(options[["colorGroupVariables"]], `[[`, character(1L), "variable")
+    assignedGroup          <- vapply(options[["colorGroupVariables"]], `[[`, character(1L), "group")
+
+    newOrder <- match(fittedVariablesOrder, assignedVariablesOrder)
+
+    assignedVariablesOrder <- assignedVariablesOrder[newOrder]
+    assignedGroup          <- assignedGroup[newOrder]
 
     if (length(unique(assignedGroup)) > 1L) {
 


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/3024
Fixes https://forum.cogsci.nl/discussion/9830

This bug likely got introduces by preloaddata.
